### PR TITLE
fix: crash on node version before node 22

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,8 +7,7 @@
         "@expo/cli": "^0.24.13",
         "@expo/config": "^11.0.10",
         "cosmiconfig": "^9.0.0",
-        "env-paths": "^3.0.0",
-        "xdg-basedir": "^5.1.0",
+        "env-paths": "^2.2.1",
         "zod": "^4.0.0-beta.20250505T195954",
       },
       "devDependencies": {
@@ -376,7 +375,7 @@
 
     "env-editor": ["env-editor@0.4.2", "", {}, "sha512-ObFo8v4rQJAE59M69QzwloxPZtd33TpYEIjtKD1rrFDcM1Gd7IkDxEBU+HriziN6HSHQnBJi8Dmy+JWkav5HKA=="],
 
-    "env-paths": ["env-paths@3.0.0", "", {}, "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A=="],
+    "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
     "error-ex": ["error-ex@1.3.2", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g=="],
 
@@ -786,8 +785,6 @@
 
     "xcode": ["xcode@3.0.1", "", { "dependencies": { "simple-plist": "^1.1.0", "uuid": "^7.0.3" } }, "sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA=="],
 
-    "xdg-basedir": ["xdg-basedir@5.1.0", "", {}, "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ=="],
-
     "xml2js": ["xml2js@0.6.0", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w=="],
 
     "xmlbuilder": ["xmlbuilder@15.1.1", "", {}, "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="],
@@ -839,8 +836,6 @@
     "compression/negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
 
     "connect/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
-
-    "cosmiconfig/env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
     "finalhandler/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "expo-build-disk-cache",
 	"description": "A plugin for Expo CLI that provides disk-based app build caching",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"author": {
 		"name": "WookieFPV (Lukas Müller)",
 		"url": "github.com/WookieFPV"
@@ -27,8 +27,7 @@
 		"@expo/cli": "^0.24.13",
 		"@expo/config": "^11.0.10",
 		"cosmiconfig": "^9.0.0",
-		"env-paths": "^3.0.0",
-		"xdg-basedir": "^5.1.0",
+		"env-paths": "^2.2.1",
 		"zod": "^4.0.0-beta.20250505T195954"
 	},
 	"devDependencies": {

--- a/src/__tests__/resolveBuildCache.test.ts
+++ b/src/__tests__/resolveBuildCache.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "bun:test";
+import os from "node:os";
+import path from "node:path";
+import type { ResolveBuildCacheProps } from "@expo/config";
+import { file } from "bun";
+import env from "env-paths";
+import DiskBuildCacheProvider from "../index.ts";
+
+const mockAppBuild = async (fingerprintHash: string) => {
+	const tmpDir = env("expo-build-disk-cache", { suffix: "tests" }).temp;
+	const appFile = file(path.join(tmpDir, `${fingerprintHash}.apk`));
+	await appFile.write("Placeholder for real apk file");
+	if (!appFile.name) throw new Error("mockBuild failed");
+	return appFile.name;
+};
+
+const baseOptions: Omit<ResolveBuildCacheProps, "fingerprintHash"> = {
+	platform: "android",
+	projectRoot: process.cwd(),
+	runOptions: {},
+};
+
+describe("Disk Cache Provider", () => {
+	it("Run without crashing", async () => {
+		const options = { ...baseOptions, fingerprintHash: crypto.randomUUID() };
+		const args = { cacheDir: "~/my-cache-dir/" };
+
+		const result = await DiskBuildCacheProvider.resolveBuildCache(
+			options,
+			args,
+		);
+		expect(result).toBeNull();
+	});
+
+	it("save and read builds to disk", async () => {
+		const options = { ...baseOptions, fingerprintHash: crypto.randomUUID() };
+		const args = {};
+
+		const resultRead1 = await DiskBuildCacheProvider.resolveBuildCache(
+			options,
+			args,
+		);
+		expect(resultRead1).toBeNull();
+
+		const buildPath = await mockAppBuild(options.fingerprintHash);
+
+		const resultWrite = await DiskBuildCacheProvider.uploadBuildCache(
+			{ ...options, buildPath },
+			args,
+		);
+		expect(resultWrite).toBeString();
+
+		const resultRead2 = await DiskBuildCacheProvider.resolveBuildCache(
+			options,
+			args,
+		);
+		expect(resultRead2).toBeString();
+	});
+
+	it("should use cacheDir Config value (cacheDir)", async () => {
+		const options = { ...baseOptions, fingerprintHash: crypto.randomUUID() };
+		const args = { cacheDir: "~/my-cache-dir/" };
+
+		const resultRead1 = await DiskBuildCacheProvider.resolveBuildCache(
+			options,
+			args,
+		);
+		expect(resultRead1).toBeNull();
+
+		// Create a file to simulate a build output
+		const buildPath = await mockAppBuild(options.fingerprintHash);
+
+		const resultWrite = await DiskBuildCacheProvider.uploadBuildCache(
+			{ ...options, buildPath },
+			args,
+		);
+		expect(resultWrite).toBeString();
+		expect(resultWrite).toInclude(args.cacheDir.replace("~", os.homedir));
+	});
+});

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,8 +1,8 @@
 import { cosmiconfigSync } from "cosmiconfig";
 import envPaths from "env-paths";
-import { xdgConfig } from "xdg-basedir";
 import { z } from "zod";
 import { dedupeArray } from "../utils/dedupeArray.ts";
+import { xdgConfig } from "../utils/npmXdgBasedir.ts";
 import {
 	NumberLikeSchema,
 	booleanLikeSchema,
@@ -79,7 +79,7 @@ const configSchema = z
 let config: Config | null = null;
 
 export function getConfig(appConfig?: Partial<Config>): Config {
-	if (config) return config; // Return cached config if already loaded
+	if (config && !appConfig) return config; // Return cached config if already loaded & no new appConfig is passed
 
 	const explorerSync = cosmiconfigSync(moduleName, {
 		searchPlaces,

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,9 +101,9 @@ async function writeToDisk(
 	}
 }
 
-const DiskBuildCacheProvider: BuildCacheProviderPlugin<Config> = {
+const DiskBuildCacheProvider = {
 	resolveBuildCache: readFromDisk,
 	uploadBuildCache: writeToDisk,
-};
+} satisfies BuildCacheProviderPlugin<Config>;
 
 export default DiskBuildCacheProvider;

--- a/src/utils/npmXdgBasedir.ts
+++ b/src/utils/npmXdgBasedir.ts
@@ -1,0 +1,15 @@
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Code from https://github.com/sindresorhus/xdg-basedir
+ * Had to copy the code here because I want to publish cjs (to ensure compatibility with node 18)
+ * The package is esm only
+ */
+
+const homeDirectory = os.homedir();
+const { env } = process;
+
+export const xdgConfig =
+	env["XDG_CONFIG_HOME"] ||
+	(homeDirectory ? path.join(homeDirectory, ".config") : undefined);

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -4,6 +4,8 @@ export default defineConfig({
 	entry: ["src/index.ts"],
 	format: ["cjs"],
 	clean: true,
-	splitting: false,
-	dts: false,
+	splitting: true,
+	dts: true,
+	platform: "node",
+	target: "node18",
 });


### PR DESCRIPTION
fix: crash on node version before node 22.
by removing esm only package & update bundling config (fix issue #8)

The reason was that `env-paths V3` and `xdg-basedir` are esm only packages.
