### PR TITLE
docs: clarify expo run-only limitation, add CONTRIBUTING.md; fix minor bugs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing
+
+Thanks for considering a contribution to `expo-build-disk-cache`!
+
+## Setup
+
+This project uses [Bun](https://bun.sh/).
+
+```bash
+bun install
+```
+
+## Development
+
+```bash
+bun run build:dev   # build in watch mode
+bun test             # run tests
+bun run typecheck    # run tsc
+bun run lint         # run biome, with autofix
+```
+
+`lefthook` runs lint/format checks on commit — no extra setup needed after `bun install`.
+
+## Making Changes
+
+1. Fork the repo and create a branch off `main`.
+2. Make your change, with tests covering new behavior where practical.
+3. Run `bun run typecheck`, `bun run lint:CI`, and `bun test` locally — CI runs the same checks.
+4. For any user-facing change, add a changeset:
+   ```bash
+   bun run changeset
+   ```
+   This records what changed and at what semver bump, and generates the `CHANGELOG.md` entry on release. Commit the generated file in `.changeset/`.
+5. Open a pull request. GitHub Actions will run typecheck, lint, tests, and build automatically.
+
+## Releasing
+
+Releases are handled by [Changesets](https://github.com/changesets/changesets) via GitHub Actions — see the [Releases section](./README.md#-releases) in the README. Contributors don't need to publish anything manually.
+
+## Reporting Issues
+
+Please include:
+
+- The Expo SDK version and platform (iOS/Android)
+- Your `buildCacheProvider` configuration
+- Whether you're running `expo run:android`/`expo run:ios` directly, or a different build pipeline (this plugin only works with `expo run:*` — see the [README limitations section](./README.md#️-how-it-works--limitations))
+- Relevant logs with `debug: true` enabled

--- a/Configuration.md
+++ b/Configuration.md
@@ -69,6 +69,8 @@ By default, the cache is stored in the system temporary directory, which may be 
 
 **expo-build-disk-cache** can be used in CI/CD environments by preserving the entire cache directory between workflow runs.
 
+> **Important:** the cache is only consulted by `expo run:android` / `expo run:ios`. If your CI pipeline runs `expo prebuild` and then builds natively (Gradle, Fastlane, `eas build --local`, Xcode, etc.), this plugin has no effect — those commands don't go through Expo's build cache provider API. This setup works well for CI jobs that run `expo run:*` to launch E2E tests on a simulator/emulator.
+
 ### Setup Instructions
 
 1. Configure a cache directory in your project settings or via the `$DISK_CACHE_CACHE_DIR` environment variable (recommended: `node_modules/.expo-build-disk-cache`)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ npm install --save-dev expo-build-disk-cache
 
 ---
 
+## ⚠️ How It Works & Limitations
+
+This plugin hooks into Expo's `buildCacheProvider` API, which is only consulted by **`npx expo run:android`** and **`npx expo run:ios`**.
+
+- ✅ Works with `expo run:android` / `expo run:ios` (including in CI, e.g. for E2E tests on a simulator/emulator).
+- ❌ Does **not** cache builds produced by `expo prebuild` + a separate native build step (Gradle, Fastlane, `eas build --local`, Xcode, etc.) — those commands never call the build cache provider, so there's nothing for this plugin to intercept.
+
+If your CI pipeline builds natively without `expo run`, this plugin won't help — see [#24](https://github.com/WookieFPV/expo-build-disk-cache/issues/24) for the full discussion.
+
+---
+
 See the full [Configuration Guide](./Configuration.md) for advanced options, cache cleanup, CI setup, and remote caching.
 
 ---

--- a/src/cache/fileCache.ts
+++ b/src/cache/fileCache.ts
@@ -76,7 +76,7 @@ export const fileCacheFactory = (
 			const mtimeMs = stats.mtimeMs;
 			const ageMs = now - mtimeMs;
 			const ageDays = ageMs / (1000 * 60 * 60 * 24);
-			const shouldDelete = ageDays > cacheGcTimeDays && !appPath?.includes(file);
+			const shouldDelete = ageDays > cacheGcTimeDays && path.basename(appPath) !== file;
 
 			if (file.endsWith(".apk") && stats.isFile()) {
 				logger.debug(

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -4,8 +4,8 @@ const voidFn = () => {};
 
 export const logger: Pick<typeof console, "log" | "debug" | "info" | "warn" | "error"> = {
 	log: console.log,
-	debug: (...args) => (getConfig().debug ? console.debug(...args) : voidFn),
-	info: (...args) => (getConfig().debug ? console.info(...args) : voidFn),
+	debug: (...args) => (getConfig().debug ? console.debug(...args) : voidFn()),
+	info: (...args) => (getConfig().debug ? console.info(...args) : voidFn()),
 	warn: console.warn,
 	error: console.error,
 };


### PR DESCRIPTION
## Summary

Small, low-risk fixes from a repo review, all "not too complex" polish items:

- **Docs**: add a "How It Works & Limitations" section to README.md and a matching note in Configuration.md explaining that the cache provider only works with `expo run:android`/`expo run:ios`, not with `expo prebuild` + separate native build tooling (Gradle, Fastlane, `eas build --local`). This is the exact confusion behind the long, still-open discussion in #24.
- **CONTRIBUTING.md**: setup, dev scripts, changesets workflow, and what to include when filing an issue.
- **Bug fix**: `src/logger.ts` — `logger.debug`/`logger.info` returned the no-op `voidFn` reference instead of calling it when debug mode is off. Harmless today since the return value is unused, but incorrect.
- **Robustness fix**: `src/cache/fileCache.ts` — the GC "don't delete the file currently in use" check used a substring match (`appPath?.includes(file)`) between a full path and a bare filename. Replaced with an exact basename comparison.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint:CI` passes
- [x] `bun test` — 47/49 pass; the 2 failing perf tests (`resolveBuildCache.perf.test.ts`) fail identically on `main` without these changes (verified via `git stash`) — they're disk-I/O-speed thresholds that don't hold in this sandboxed environment, unrelated to this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_012Nb2Tu8WX3ddLmFLuXEHQT)_