### PR TITLE
test: GC in-use guard regression test; simplify logger; add changeset

### DIFF
--- a/.changeset/tidy-cache-gc-guard.md
+++ b/.changeset/tidy-cache-gc-guard.md
@@ -1,0 +1,5 @@
+---
+"expo-build-disk-cache": patch
+---
+
+Fix cache garbage collection incorrectly protecting files from deletion via a substring path match; it now compares exact basenames. Also fix `logger.debug`/`logger.info` returning the no-op function reference instead of invoking it when debug mode is off.

--- a/src/cache/__tests__/fileCache.cleanup.test.ts
+++ b/src/cache/__tests__/fileCache.cleanup.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { ResolveBuildCacheProps } from "@expo/config";
+import type { Config } from "../../config/config.ts";
+import { fileExists } from "../../file/fileExists.ts";
+import { fileCacheFactory } from "../fileCache.ts";
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+const baseArgs = {
+	platform: "android",
+	projectRoot: process.cwd(),
+	runOptions: {},
+	fingerprintHash: "test",
+} satisfies ResolveBuildCacheProps;
+
+const makeStale = async (filePath: string, days: number) => {
+	const t = new Date(Date.now() - days * DAY_MS);
+	await fs.utimes(filePath, t, t);
+};
+
+const makeConfig = (cacheDir: string, appPath: string): Config => ({
+	cacheDir,
+	enable: true,
+	debug: false,
+	cacheGcTimeDays: 7,
+	getPath: () => appPath,
+});
+
+describe("fileCache cleanup — GC in-use guard", () => {
+	let cacheDir: string;
+
+	beforeEach(async () => {
+		cacheDir = await fs.mkdtemp(path.join(os.tmpdir(), "disk-cache-gc-"));
+	});
+
+	afterEach(async () => {
+		await fs.rm(cacheDir, { recursive: true, force: true });
+	});
+
+	it("keeps the in-use cached file even when it is older than the GC threshold", async () => {
+		const inUse = path.join(cacheDir, "fingerprint.in-use.apk");
+		await fs.writeFile(inUse, "apk");
+		await makeStale(inUse, 30);
+
+		await fileCacheFactory(baseArgs, makeConfig(cacheDir, inUse)).cleanup();
+
+		expect(await fileExists(inUse)).toBe(true);
+	});
+
+	it("deletes an unrelated stale cache file", async () => {
+		const stale = path.join(cacheDir, "fingerprint.stale.apk");
+		await fs.writeFile(stale, "apk");
+		await makeStale(stale, 30);
+
+		const inUse = path.join(cacheDir, "fingerprint.in-use.apk");
+		await fileCacheFactory(baseArgs, makeConfig(cacheDir, inUse)).cleanup();
+
+		expect(await fileExists(stale)).toBe(false);
+	});
+
+	it("deletes a stale file whose name is a substring of the in-use path but not an exact basename match", async () => {
+		// Regression test for the previous substring guard (`appPath.includes(file)`):
+		// the in-use path embeds another cached file's name as a directory segment, so
+		// the old substring check would wrongly protect the stale ghost file from GC.
+		const ghostName = "fingerprint.ghost.apk";
+		const ghost = path.join(cacheDir, ghostName);
+		await fs.writeFile(ghost, "apk");
+		await makeStale(ghost, 30);
+
+		const inUsePath = path.join(cacheDir, ghostName, "fingerprint.real.apk");
+		await fileCacheFactory(baseArgs, makeConfig(cacheDir, inUsePath)).cleanup();
+
+		expect(await fileExists(ghost)).toBe(false);
+	});
+});

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,11 +1,13 @@
 import { getConfig } from "./config/config";
 
-const voidFn = () => {};
-
 export const logger: Pick<typeof console, "log" | "debug" | "info" | "warn" | "error"> = {
 	log: console.log,
-	debug: (...args) => (getConfig().debug ? console.debug(...args) : voidFn()),
-	info: (...args) => (getConfig().debug ? console.info(...args) : voidFn()),
+	debug: (...args) => {
+		if (getConfig().debug) console.debug(...args);
+	},
+	info: (...args) => {
+		if (getConfig().debug) console.info(...args);
+	},
 	warn: console.warn,
 	error: console.error,
 };


### PR DESCRIPTION
## Summary

Follow-up to the review of #97, applying the non-blocking suggestions from that review. **This PR is stacked on top of #97** (base branch `claude/repo-review-career-7wobte`), so it should be retargeted to `main` once #97 merges.

- **Regression test** (`src/cache/__tests__/fileCache.cleanup.test.ts`): covers the GC "don't delete the in-use file" guard fixed in #97. Three cases — the in-use cached file is preserved even when stale, unrelated stale files are collected, and (the case that pins the fix) a stale file whose name is a substring of the in-use path but not an exact basename match is now correctly deleted. Verified this third case **fails** against the old `appPath.includes(file)` substring logic and **passes** with the exact-basename comparison.
- **Logger cleanup** (`src/logger.ts`): rewrote `logger.debug`/`logger.info` as a plain `if (getConfig().debug) console.debug(...)` conditional, dropping the now-unused `voidFn` no-op. Behaviourally equivalent and drops the pointless return value entirely.
- **Changeset** (`.changeset/tidy-cache-gc-guard.md`): `patch` bump documenting the two bug fixes from #97, per the workflow in the new `CONTRIBUTING.md`.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint:CI` passes (`lefthook` pre-commit check also clean)
- [x] `bun test` — 50/52 pass; the 2 failing tests are the pre-existing `resolveBuildCache.perf.test.ts` disk-I/O-speed thresholds that also fail on the base branch in this sandbox, unrelated to this change.
- [x] Confirmed the new substring-collision test fails on the pre-#97 logic and passes on the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWLYRmUCHrFFNiprZteWxo

---
_Generated by [Claude Code](https://claude.ai/code/session_01YWLYRmUCHrFFNiprZteWxo)_