### PR TITLE
fix(ci): correct malformed actions/checkout SHA in compatibility workflow

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -29,7 +29,7 @@ jobs:
           - bun
 
     steps:
-      - uses: actions/checkout@de0fac2e4505abe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0


### PR DESCRIPTION
## Summary

Every job in the new `package compatibility` workflow failed before running a single step:

```
Error: Unable to resolve action `actions/checkout@de0fac2e4505abe0009e67214ff5f5447ce83dd`,
unable to find version `de0fac2e4505abe0009e67214ff5f5447ce83dd`
```

The pin in `.github/workflows/compatibility.yml` was **39 characters** instead of 40, with a transposed segment (`…4505ab…` rather than `…4500dab…`). Because failure happens at action-resolution time, all 16 matrix combinations died identically — which is why it looked like the whole pipeline was broken.

The fix is to use the same v6.0.2 commit SHA that `ci.yml` and `release.yml` already pin correctly.

Scope note: `compatibility.yml` was added by `a8997ad` on `lazy-remote-cache-providers` and does not exist on `main`, so this bug never reached `main`. This PR is therefore based on `lazy-remote-cache-providers` to keep the diff to the single-line fix.

## Verification

Confirmed via the Actions API that `ci` was green on the same push and only `package compatibility` failed — consistent with the defect being isolated to this one file.

Every pinned SHA across all three workflows was re-checked against its upstream repository with `git ls-remote`; all four are now 40 characters and resolve to the tag named in the trailing comment:

| Action | SHA | Resolves to |
| --- | --- | --- |
| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | v6.0.2 |
| `actions/setup-node` | `53b83947a5a98c8d113130e565377fae1a50d02f` | v6.3.0 |
| `oven-sh/setup-bun` | `0c5077e51419868618aeaa5fe8019c62421857d6` | v2.2.0 |
| `changesets/action` | `6a0a831ff30acef54f2c6aa1cbbc1096b066edaf` | v1.7.0 |

This unblocks action resolution so the matrix can actually execute. The compatibility jobs have never completed a run, so this is the first real signal from them — any failure in the install/verify steps would be a genuine finding rather than a regression from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QsWLn5ToNnYEMzipkL7pF9

---
_Generated by [Claude Code](https://claude.ai/code/session_01QsWLn5ToNnYEMzipkL7pF9)_