### PR TITLE
fix: use renamed changesets/action inputs in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,9 +57,9 @@ jobs:
       - name: Create release PR or publish
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         with:
-          commit: "chore: release"
-          title: "chore: release"
-          version: bun run version-packages
-          publish: bun run release
+          commit-message: "chore: release"
+          pr-title: "chore: release"
+          version-script: bun run version-packages
+          publish-script: bun run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
The pinned `changesets/action` (v2.1.1) renamed its inputs and now hard-fails on the old names, breaking the `release` workflow on `main`.

Renames:
- `commit` → `commit-message`
- `title` → `pr-title`
- `version` → `version-script`
- `publish` → `publish-script`

## Test plan
- CI validates the workflow YAML change.
- Next push to `main` should let the `release` job proceed past input validation.